### PR TITLE
fix: prevent description from being cut off

### DIFF
--- a/client/src/components/Details.tsx
+++ b/client/src/components/Details.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import Link from 'next/link';
 import { useEffect, useRef } from 'react';
 import { AiFillCaretDown } from 'react-icons/ai';
 import { GiCheckMark } from 'react-icons/gi';
@@ -17,14 +16,14 @@ function DetailLink({
   linkClickHandler: () => void;
 }) {
   return (
-    <Link
+    <a
       onClick={linkClickHandler}
       href={link.href}
       className="flex gap-2 items-center p-2 pl-7 border-b border-gray-600"
     >
       <GiCheckMark className={currentLinkKey == linkKey ? '' : 'invisible'} />
       <span className="hover:text-primary-orange">{link.linkText}</span>
-    </Link>
+    </a>
   );
 }
 

--- a/client/src/components/GistForm.tsx
+++ b/client/src/components/GistForm.tsx
@@ -140,17 +140,20 @@ export default function GistForm({
             </div>
           )}
           <div>
-            <input
-              type="text"
-              name="description"
-              id="description"
-              placeholder="Gist description"
-              className="w-full rounded-md p-2 text-sm bg-secondary-gray text-primary-white border border-gray-600 read-only:bg-primary-gray read-only:border-none read-only:p-0 read-only:text-sm read-only:pointer-events-none"
-              value={values.description}
-              onChange={handleChange}
-              onBlur={handleBlur}
-              readOnly={readOnly}
-            />
+            {readOnly ? (
+              <span>{values.description}</span>
+            ) : (
+              <input
+                type="text"
+                name="description"
+                id="description"
+                placeholder="Gist description"
+                className="w-full rounded-md p-2 text-sm bg-secondary-gray text-primary-white border border-gray-600 read-only:bg-primary-gray read-only:border-none read-only:p-0 read-only:text-sm read-only:pointer-events-none"
+                value={values.description}
+                onChange={handleChange}
+                onBlur={handleBlur}
+              />
+            )}
           </div>
           <div className="flex flex-col flex-1">
             <div className="flex items-start justify-between px-4 py-2 bg-secondary-gray border border-gray-600 rounded-t-md">


### PR DESCRIPTION
+ When gist form is displayed in a read only state, the description
  field is cut off. This commit fixes that by displaying the
  description in a span instead of an input when the form is in a
  read only state.
